### PR TITLE
handle browse command not installed

### DIFF
--- a/bin/open-notebook.sh
+++ b/bin/open-notebook.sh
@@ -6,6 +6,7 @@ URL=$($SCRIPTPATH/url-to-notebook.sh)
 
 if test -z $URL; then
     echo "Could not find notebook details, have you run start.sh?"
-else
-    browse $URL
+elif ! command browse $URL ; then
+    echo "Could not open browser automatically"
+    echo "Please open a browser at $URL"
 fi


### PR DESCRIPTION
When I tried to run `bin/open-notebook.sh` on my macbook (with zsh), I got: 

> ./bin/open-notebook.sh: line 9: browse: command not found

This PR catches that error sensibly and prints the URL instead.