### PR TITLE
Fix #32

### DIFF
--- a/Training_analysis.ipynb
+++ b/Training_analysis.ipynb
@@ -53,7 +53,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -75,7 +75,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 2,
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -124,7 +124,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -172,7 +172,7 @@
     "log = DeepRacerLog(model_logs_root)\n",
     "\n",
     "# load logs into a dataframe\n",
-    "log.load()\n",
+    "log.load_robomaker_logs()\n",
     "\n",
     "try:\n",
     "    pprint(log.agent_and_network())\n",
@@ -3152,7 +3152,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/Training_analysis.py
+++ b/Training_analysis.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: light
 #       format_version: '1.5'
-#       jupytext_version: 1.13.8
+#       jupytext_version: 1.14.1
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python
@@ -114,7 +114,7 @@ model_logs_root = 'logs/sample-console-logs'
 log = DeepRacerLog(model_logs_root)
 
 # load logs into a dataframe
-log.load()
+log.load_robomaker_logs()
 
 try:
     pprint(log.agent_and_network())


### PR DESCRIPTION
Small adjustment that ensures that only Robomaker logs are read in, and that the action space and hyperparameters are read out of the log file.