### PR TITLE
Fix syntax error in Action Space extration

### DIFF
--- a/ActionSpace_analysis.ipynb
+++ b/ActionSpace_analysis.ipynb
@@ -2375,7 +2375,7 @@
     "\n",
     "maxThrottle = df.speed.max()\n",
     "\n",
-    "AS = df[df['steps'] != 0].groupby(['action'], as_index=False)['steering_angle','speed'].median()\n",
+    "AS = df[df['steps'] != 0].groupby(['action'], as_index=False)[['steering_angle','speed']].median()\n",
     "asl = [None] * AS.shape[0]\n",
     "for i in range(0,AS.shape[0]):\n",
     "    j = AS.action[i].astype(int)\n",

--- a/ActionSpace_analysis.py
+++ b/ActionSpace_analysis.py
@@ -218,7 +218,7 @@ class act(object):
 
 maxThrottle = df.speed.max()
 
-AS = df[df['steps'] != 0].groupby(['action'], as_index=False)['steering_angle','speed'].median()
+AS = df[df['steps'] != 0].groupby(['action'], as_index=False)[['steering_angle','speed']].median()
 asl = [None] * AS.shape[0]
 for i in range(0,AS.shape[0]):
     j = AS.action[i].astype(int)


### PR DESCRIPTION
Had a syntax error trying to run this notebook for the first time. I had the following error

```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[45], line 17
     12         self.color = color
     14 maxThrottle = df.speed.max()
---> 17 AS = df[df['steps'] != 0].groupby(['action'], as_index=False)['steering_angle','speed'].median()
     18 asl = [None] * AS.shape[0]
     19 for i in range(0,AS.shape[0]):

File /usr/local/lib/python3.8/dist-packages/pandas/core/groupby/generic.py:1767, in DataFrameGroupBy.__getitem__(self, key)
   1763 # per GH 23566
   1764 if isinstance(key, tuple) and len(key) > 1:
   1765     # if len == 1, then it becomes a SeriesGroupBy and this is actually
   1766     # valid syntax, so don't raise
-> 1767     raise ValueError(
   1768         "Cannot subset columns with a tuple with more than one element. "
   1769         "Use a list instead."
   1770     )
   1771 return super().__getitem__(key)

ValueError: Cannot subset columns with a tuple with more than one element. Use a list instead.
```

After some investigation with the [`groupby` documentation](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.groupby.html), it appears that the column selection syntax may have changed since this code was written. 